### PR TITLE
fix Markdown miss

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#lastmess.vim
+# lastmess.vim
 
-##概要
+## 概要
 *lastmess* はVimの`:messages`の最後のほうだけを見るためのプラグインです。最終行からカウントで指定した行数分、`:messages`を見ることが出来ます。  


### PR DESCRIPTION
 ref https://gfx.hatenablog.com/entry/2017/08/14/174621

Markdown need space between heading sharp and title

```markdown
# heading
```

---

プラグインを利用させていただいているので、修正の手間を減らすくらいの役には立つかなと思いPRします。
